### PR TITLE
make `triton cloudapi` more like curl

### DIFF
--- a/lib/do_cloudapi.js
+++ b/lib/do_cloudapi.js
@@ -16,22 +16,32 @@ function do_cloudapi(subcmd, opts, args, callback) {
     if (opts.help) {
         this.do_help('help', {}, [subcmd], callback);
         return;
-    } else if (args.length < 1 || args.length > 2) {
+    } else if (args.length < 1) {
         callback(new Error('invalid arguments'));
         return;
     }
 
-    var method = args[0];
-    var path = args[1];
-    if (path === undefined) {
-        path = method;
-        method = 'GET';
-    }
+    var path = args[0];
 
     var reqopts = {
-        method: method.toLowerCase(),
+        method: opts.method.toLowerCase(),
+        headers: {},
         path: path
     };
+
+    // parse -H headers
+    for (var i = 0; i < opts.header.length; i++) {
+        var raw = opts.header[i];
+        var j = raw.indexOf(':');
+        if (j < 0) {
+            callback(new Error('failed to parse header: ' + raw));
+            return;
+        }
+        var header = raw.substr(0, j);
+        var value = raw.substr(j + 1).leftTrim();
+
+        reqopts.headers[header] = value;
+    }
 
     this.tritonapi.cloudapi._request(reqopts, function (err, req, res, body) {
         if (err) {
@@ -63,6 +73,18 @@ do_cloudapi.options = [
         help: 'Show this help.'
     },
     {
+        names: ['method', 'X'],
+        type: 'string',
+        default: 'GET',
+        help: 'Request method to use. Default is "GET".'
+    },
+    {
+        names: ['header', 'H'],
+        type: 'arrayOfString',
+        default: [],
+        help: 'Headers to send with request.'
+    },
+    {
         names: ['headers', 'i'],
         type: 'bool',
         help: 'Print response headers to stderr.'
@@ -72,7 +94,7 @@ do_cloudapi.help = (
     'Raw cloudapi request.\n'
     + '\n'
     + 'Usage:\n'
-    + '     {{name}} <method> <endpoint>\n'
+    + '     {{name}} [-X method] [-H header=value] <endpoint>\n'
     + '\n'
     + '{{options}}'
 );


### PR DESCRIPTION
- `-X method` to specify method
- `-H 'key: value'` to specify header

This changes the usage slightly...

```
triton cloudapi POST /foo
```

becomes

```
triton cloudapi -X POST /foo
```

to match `curl`
