### PR TITLE
Protect against cache lookup returning null

### DIFF
--- a/lib/tritonapi.js
+++ b/lib/tritonapi.js
@@ -354,10 +354,12 @@ TritonApi.prototype.getImage = function getImage(opts, cb) {
                         next(err);
                         return;
                     }
-                    for (var i = 0; i < images.length; i++) {
-                        if (images[i].id === opts.name) {
-                            img = images[i];
-                            break;
+                    if (images) {
+                        for (var i = 0; i < images.length; i++) {
+                            if (images[i].id === opts.name) {
+                                img = images[i];
+                                break;
+                            }
                         }
                     }
                     next();


### PR DESCRIPTION
If the cache file does not exist _cacheGetJson will not pass any value to the callback.

In the getImage function the callback passed to _cacheGetJson assumes if there was no error value then the second argument must be an array.

Add some logic to guard against null values before iterating over the array.

Fixes #93