### PR TITLE
Patch missing rename from 4760defd05348b

### DIFF
--- a/lib/do_image/do_create.js
+++ b/lib/do_image/do_create.js
@@ -41,7 +41,7 @@ function do_create(subcmd, opts, args, cb) {
 
     vasync.pipeline({arg: {}, funcs: [
         function loadTags(ctx, next) {
-            mat.tagsFromOpts(opts, log, function (err, tags) {
+            mat.tagsFromCreateOpts(opts, log, function (err, tags) {
                 if (err) {
                     next(err);
                     return;


### PR DESCRIPTION
The fix for joyent/node-triton#88 renamed the metadataandtags
function 'tagsFromOpts' to 'tagsFromCreateOpts' but didn't
rename all of it's uses.