### PR TITLE
Upgrading restify-clients@1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node-uuid": "1.4.3",
     "once": "1.3.2",
     "read": "1.0.7",
-    "restify-clients": "1.1.0",
+    "restify-clients": "1.4.0",
     "restify-errors": "3.0.0",
     "rimraf": "2.4.4",
     "semver": "5.1.0",


### PR DESCRIPTION
The old version had a dependency that linked to
git+https://git@github.com/restify/errors.git#master which could cause
issues if master of the project makes any breaking changes.
