### PR TITLE
Fix bash completion setup help on Linux

### DIFF
--- a/lib/do_completion.js
+++ b/lib/do_completion.js
@@ -71,7 +71,7 @@ do_completion.help = [
     '        && source /usr/local/etc/bash_completion.d/{{name}}',
     '',
     'Installation (Linux):',
-    '    sudo {{name}} completion > /etc/bash_completion.d/{{name}} \\',
+    '    {{name}} completion | sudo tee /etc/bash_completion.d/{{name}} \\',
     '        && source /etc/bash_completion.d/{{name}}',
     '',
     'Alternative installation:',


### PR DESCRIPTION
Executing triton with sudo doesn't allow writing to /etc/bash_completion.d/triton on it's own. Instead, we should pipe to `sudo tee` as seen in the commit diff.