### PR TITLE
#290 Use XDG_CONFIG_HOME as the default config directory

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,6 +20,7 @@
  */
 
 var mod_path = require('path');
+var fs = require('fs');
 
 
 // ---- determining constants
@@ -43,7 +44,15 @@ if (process.env.TRITONTEST_CLI_CONFIG_DIR) {
      */
     CLI_CONFIG_DIR = mod_path.resolve(process.env.APPDATA, 'Joyent', 'Triton');
 } else {
-    CLI_CONFIG_DIR = mod_path.resolve(process.env.HOME, '.triton');
+    var oldConfigDir = mod_path.resolve(process.env.HOME, '.triton');
+    // If an old config is already available, use it instead for backwards compatability purposes
+    if (fs.existsSync(oldConfigDir) && fs.statSync(oldConfigDir).isDirectory()) {
+      CLI_CONFIG_DIR = oldConfigDir;
+    } else {
+        // Default to XDG_CONFIG_HOME/triton
+        const xdgConfigDir = process.env.XDG_CONFIG_HOME || mod_path.resolve(process.env.HOME, '.config');
+        CLI_CONFIG_DIR = mod_path.resolve(xdgConfigDir, 'triton');
+    }
 }
 
 // <Network Object Key> -> <expected typeof>


### PR DESCRIPTION
Closes #290 
This is a quick fix to have the cli honor XDG conventions. This introduces two synchronous fs calls, which might be too much of a performance hit. The easy way to fix this would be not have backwards compatibility for existing `$HOME/.triton` directories, or to somehow migrate those.
