### PR TITLE
joyent/node-triton#294 triton profile should generate certs for cmon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Known issues:
 
 ## not yet released
 
+- [joyent/node-triton#294] `triton profile` should generate certs for cmon
 - [TRITON-426] Provide access to KVM Console for end users. Use
   `triton instance vnc` to start a local VNC server for your instance.
 - [TRITON-1870] Fix snapshot validation being ignored by

--- a/lib/do_profile/do_cmon_certgen.js
+++ b/lib/do_profile/do_cmon_certgen.js
@@ -1,0 +1,66 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2020 Joyent Inc.
+ *
+ * `triton profile cmon-certgen ...`
+ */
+
+var assert = require('assert-plus');
+
+var errors = require('../errors');
+var profilecommon = require('./profilecommon');
+
+function do_cmon_certgen(subcmd, opts, args, cb) {
+    if (opts.help) {
+        this.do_help('help', {}, [subcmd], cb);
+        return;
+    } else if (args.length > 1) {
+        return cb(new errors.UsageError('too many arguments'));
+    }
+
+    var profileName = args[0] || this.top.tritonapi.profile.name;
+    profilecommon.profileCmonCertgen({
+        cli: this.top,
+        name: profileName,
+        yes: opts.yes,
+        lifetime: opts.lifetime
+    }, cb);
+}
+
+do_cmon_certgen.options = [
+    {
+        names: ['help', 'h'],
+        type: 'bool',
+        help: 'Show this help.'
+    },
+    {
+        names: ['lifetime', 't'],
+        type: 'number',
+        help: 'Lifetime of the generated cmon certificate, in days'
+    },
+    {
+        names: ['yes', 'y'],
+        type: 'bool',
+        help: 'Answer yes to any confirmations.'
+    }
+];
+
+do_cmon_certgen.synopses = ['{{name}} {{cmd}} [PROFILE]'];
+do_cmon_certgen.help = [
+    /* BEGIN JSSTYLED */
+    'Generate a CMON certificate with the current Triton CLI profile.',
+    '',
+    '{{usage}}',
+    '{{options}}',
+    'This only needs to be done once per cloud.'
+    /* END JSSTYLED */
+].join('\n');
+
+do_cmon_certgen.completionArgtypes = ['tritonprofile', 'none'];
+
+module.exports = do_cmon_certgen;

--- a/lib/do_profile/index.js
+++ b/lib/do_profile/index.js
@@ -5,9 +5,9 @@
  */
 
 /*
- * Copyright 2015 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  *
- * `triton image ...`
+ * `triton profile ...`
  */
 
 var Cmdln = require('cmdln').Cmdln;
@@ -42,6 +42,7 @@ function ProfileCLI(top) {
             'create',
             'edit',
             'delete',
+            'cmon-certgen',
             'docker-setup'
         ]
     });
@@ -59,6 +60,7 @@ ProfileCLI.prototype.do_set_current = require('./do_set_current');
 ProfileCLI.prototype.do_create = require('./do_create');
 ProfileCLI.prototype.do_delete = require('./do_delete');
 ProfileCLI.prototype.do_edit = require('./do_edit');
+ProfileCLI.prototype.do_cmon_certgen = require('./do_cmon_certgen');
 ProfileCLI.prototype.do_docker_setup = require('./do_docker_setup');
 
 // TODO: Would like to `triton profile update foo account=trentm ...`

--- a/lib/do_profile/profilecommon.js
+++ b/lib/do_profile/profilecommon.js
@@ -177,8 +177,6 @@ function profileCmonCertgen(opts, cb) {
     var sslCert;
     var sslKey;
 
-    console.log(JSON.stringify(profile));
-
     vasync.pipeline({arg: {tritonapi: tritonapi}, funcs: [
 
         common.cliSetupTritonApi,

--- a/lib/do_profile/profilecommon.js
+++ b/lib/do_profile/profilecommon.js
@@ -164,47 +164,22 @@ function profileCmonCertgen(opts, cb) {
     if (!opts.lifetime)
         opts.lifetime = DEFAULT_CERT_LIFETIME;
 
-    var agent = new sshpk_agent.Client();
     var cli = opts.cli;
-    var cmonHost;
-    var log = cli.log;
-    var profile = tritonapi.profile;
-    var sslCert;
-    var sslKey;
     var tritonapi = cli.tritonapiFromProfileName({profileName: opts.name});
+
+    var log = cli.log;
     var yes = Boolean(opts.yes);
 
+    var profile = tritonapi.profile;
+    var cmonHost;
+
+    var agent = new sshpk_agent.Client();
+    var sslCert;
+    var sslKey;
+
+    console.log(JSON.stringify(profile));
+
     vasync.pipeline({arg: {tritonapi: tritonapi}, funcs: [
-        function cmonKeyNotice(arg, next) {
-            console.log(wordwrap('Note: CMON uses authentication via ' +
-                'client TLS certiificates.\n'));
-            console.log(wordwrap('This action will create a ' +
-                'fresh private key to be written unencrypted to disk ' +
-                'in the current working directory. Copy these files to ' +
-                'your cmon client (whether Prometheus, or something ' +
-                'else).\n'));
-            console.log(wordwrap('This key will be usable only for CMON. ' +
-                'If your SSH key is removed from your account, this CMON ' +
-                'key will no longer work.\n'));
-            if (yes) {
-                next();
-                return;
-            } else {
-                console.log(wordwrap('If you do not specifically want to use ' +
-                    'CMON, or want to set this up later, you can answer ' +
-                    '"no" here.\n'));
-            }
-            common.promptYesNo({msg: 'Continue? [y/n] '}, function (answer) {
-                if (answer !== 'y') {
-                    console.error('Skipping CMON certificate generation (you ' +
-                        'can run "triton profile cmon-certgen" later).');
-                    next(true);
-                } else {
-                    console.log();
-                    next();
-                }
-            });
-        },
 
         common.cliSetupTritonApi,
 
@@ -267,6 +242,37 @@ function profileCmonCertgen(opts, cb) {
             });
         },
 
+        function cmonKeyNotice(arg, next) {
+            console.log(wordwrap('Note: CMON uses authentication via ' +
+                'client TLS certiificates.\n'));
+            console.log(wordwrap('This action will create a ' +
+                'fresh private key which is written unencrypted to disk ' +
+                'in the current working directory. Copy these files to ' +
+                'your cmon client (whether Prometheus, or something ' +
+                'else).\n'));
+            console.log(wordwrap('This key will be usable only for CMON. ' +
+                'If your SSH key is removed from your account, this CMON ' +
+                'key will no longer work.\n'));
+            if (yes) {
+                next();
+                return;
+            } else {
+                console.log(wordwrap('If you do not specifically want to use ' +
+                    'CMON, or want to set this up later, you can answer ' +
+                    '"no" here.\n'));
+            }
+            common.promptYesNo({msg: 'Continue? [y/n] '}, function (answer) {
+                if (answer !== 'y') {
+                    console.error('Skipping CMON certificate generation (you ' +
+                        'can run "triton profile cmon-certgen" later).');
+                    next(true);
+                } else {
+                    console.log();
+                    next();
+                }
+            });
+        },
+
         function mentionSettingUp(arg, next) {
             console.log('Generating CMON certificates for profile "%s".',
                 profile.name);
@@ -301,6 +307,11 @@ function profileCmonCertgen(opts, cb) {
             var issuer = sshpk.identityFromDN('CN=' + fp);
             var certSignKey = arg.certSignKey;
 
+            /*
+             * Unlike Docker, where choosing ecdsa is somewhat arbitrary,
+             * CMON has severe performance issues with RSA at load. Using
+             * ecdsa avoids this.
+             */
             sslKey = sshpk.generatePrivateKey('ecdsa');
 
             var certOpts = {
@@ -382,32 +393,6 @@ function profileDockerSetup(opts, cb) {
     var dockerHost;
 
     vasync.pipeline({arg: {tritonapi: tritonapi}, funcs: [
-        function dockerKeyWarning(arg, next) {
-            console.log(wordwrap('WARNING: Docker uses authentication via ' +
-                'client TLS certificates that do not support encrypted ' +
-                '(passphrase protected) keys or SSH agents.\n'));
-            console.log(wordwrap('If you continue, this profile setup will ' +
-                'create a fresh private key to be written unencrypted to ' +
-                'disk in "~/.triton/docker" for use by the Docker client. ' +
-                'This key will be useable only for Docker.\n'));
-            if (yes) {
-                next();
-                return;
-            } else {
-                console.log(wordwrap('If you do not specifically want to use ' +
-                    'Docker, you can answer "no" here.\n'));
-            }
-            common.promptYesNo({msg: 'Continue? [y/n] '}, function (answer) {
-                if (answer !== 'y') {
-                    console.error('Skipping Docker setup (you can run '
-                        + '"triton profile docker-setup" later).');
-                    next(true);
-                } else {
-                    console.log();
-                    next();
-                }
-            });
-        },
 
         common.cliSetupTritonApi,
 
@@ -473,6 +458,33 @@ function profileDockerSetup(opts, cb) {
                     next(new errors.SetupError(err, format(
                         'unexpected response from cloudapi %s: %s status code',
                         profile.url, res.statusCode)));
+                }
+            });
+        },
+
+        function dockerKeyWarning(arg, next) {
+            console.log(wordwrap('WARNING: Docker uses authentication via ' +
+                'client TLS certificates that do not support encrypted ' +
+                '(passphrase protected) keys or SSH agents.\n'));
+            console.log(wordwrap('If you continue, this profile setup will ' +
+                'create a fresh private key which is written unencrypted to ' +
+                'disk in "~/.triton/docker" for use by the Docker client. ' +
+                'This key will be useable only for Docker.\n'));
+            if (yes) {
+                next();
+                return;
+            } else {
+                console.log(wordwrap('If you do not specifically want to use ' +
+                    'Docker, you can answer "no" here.\n'));
+            }
+            common.promptYesNo({msg: 'Continue? [y/n] '}, function (answer) {
+                if (answer !== 'y') {
+                    console.error('Skipping Docker setup (you can run '
+                        + '"triton profile docker-setup" later).');
+                    next(true);
+                } else {
+                    console.log();
+                    next();
                 }
             });
         },

--- a/lib/do_profile/profilecommon.js
+++ b/lib/do_profile/profilecommon.js
@@ -35,7 +35,8 @@ var common = require('../common');
 var mod_config = require('../config');
 var errors = require('../errors');
 
-var DEFAULT_LIFETIME = 3650;
+var DEFAULT_CERT_LIFETIME = 3650;
+var SECONDS_PER_DAY = 60 * 60 * 24; // 86400s
 
 // --- internal support functions
 
@@ -152,6 +153,7 @@ function setCurrentProfile(opts, cb) {
  *        certificate valid for. Defaults to 3650 (10 years).
  */
 function profileCmonCertgen(opts, cb) {
+    assert.object(opts, 'opts');
     assert.object(opts.cli, 'opts.cli');
     assert.string(opts.name, 'opts.name');
     assert.optionalBool(opts.yes, 'opts.yes');
@@ -160,21 +162,17 @@ function profileCmonCertgen(opts, cb) {
 
     /* Default to a 10 year certificate. */
     if (!opts.lifetime)
-        opts.lifetime = DEFAULT_LIFETIME;
-
-
-    var cli = opts.cli;
-    var tritonapi = cli.tritonapiFromProfileName({profileName: opts.name});
-
-    var yes = Boolean(opts.yes);
-    var log = cli.log;
-
-    var profile = tritonapi.profile;
-    var cmonHost;
+        opts.lifetime = DEFAULT_CERT_LIFETIME;
 
     var agent = new sshpk_agent.Client();
+    var cli = opts.cli;
+    var cmonHost;
+    var log = cli.log;
+    var profile = tritonapi.profile;
     var sslCert;
     var sslKey;
+    var tritonapi = cli.tritonapiFromProfileName({profileName: opts.name});
+    var yes = Boolean(opts.yes);
 
     vasync.pipeline({arg: {tritonapi: tritonapi}, funcs: [
         function cmonKeyNotice(arg, next) {
@@ -306,7 +304,7 @@ function profileCmonCertgen(opts, cb) {
             sslKey = sshpk.generatePrivateKey('ecdsa');
 
             var certOpts = {
-                lifetime: 24*3600*opts.lifetime,
+                lifetime: SECONDS_PER_DAY * opts.lifetime,
                 purposes: ['signature', 'identity', 'clientAuth', 'joyentCmon']
             };
 
@@ -371,7 +369,7 @@ function profileDockerSetup(opts, cb) {
 
     /* Default to a 10 year certificate. */
     if (!opts.lifetime)
-        opts.lifetime = DEFAULT_LIFETIME;
+        opts.lifetime = DEFAULT_CERT_LIFETIME;
 
     var cli = opts.cli;
     var tritonapi = cli.tritonapiFromProfileName({profileName: opts.name});
@@ -586,7 +584,7 @@ function profileDockerSetup(opts, cb) {
             validFrom.setTime(validFrom.getTime() - 300*1000);
             var validUntil = new Date();
             validUntil.setTime(validFrom.getTime() +
-                24*3600*1000*opts.lifetime);
+                SECONDS_PER_DAY * 1000 * opts.lifetime);
             /*
              * Generate it self-signed for now -- we will clear this
              * signature out and replace it with the real one below.

--- a/lib/do_profile/profilecommon.js
+++ b/lib/do_profile/profilecommon.js
@@ -23,6 +23,7 @@ var path = require('path');
 var rimraf = require('rimraf');
 var semver = require('semver');
 var sshpk = require('sshpk');
+var sshpk_agent = require('sshpk-agent');
 var mod_url = require('url');
 var crypto = require('crypto');
 var vasync = require('vasync');
@@ -34,6 +35,7 @@ var common = require('../common');
 var mod_config = require('../config');
 var errors = require('../errors');
 
+var DEFAULT_LIFETIME = 3650;
 
 // --- internal support functions
 
@@ -136,6 +138,213 @@ function setCurrentProfile(opts, cb) {
 }
 
 /**
+ * Generate a cmon certificate/key pair for the given profile. This means
+ * checking the cloudapi has a cmon service (ListServices), finding the user's
+ * SSH *private* key, and creating the client certs that will be used to talk
+ * to the Triton CMON service.
+ *
+ * @param {Object} opts: Required.
+ *      - {Object} cli: Requried. The Triton CLI object.
+ *      - {String} name: Required. The profile name.
+ *      - {Boolean} yes: Optional. Boolean indicating if confirmation prompts
+ *        should be skipped, assuming a "yes" answer.
+ *      - {Number} lifetime: Optional. Number of days to make the CMON
+ *        certificate valid for. Defaults to 3650 (10 years).
+ */
+function profileCmonCertgen(opts, cb) {
+    assert.object(opts.cli, 'opts.cli');
+    assert.string(opts.name, 'opts.name');
+    assert.optionalBool(opts.yes, 'opts.yes');
+    assert.optionalNumber(opts.lifetime, 'opts.lifetime');
+    assert.func(cb, 'cb');
+
+    /* Default to a 10 year certificate. */
+    if (!opts.lifetime)
+        opts.lifetime = DEFAULT_LIFETIME;
+
+
+    var cli = opts.cli;
+    var tritonapi = cli.tritonapiFromProfileName({profileName: opts.name});
+
+    var yes = Boolean(opts.yes);
+    var log = cli.log;
+
+    var profile = tritonapi.profile;
+    var cmonHost;
+
+    var agent = new sshpk_agent.Client();
+    var sslCert;
+    var sslKey;
+
+    vasync.pipeline({arg: {tritonapi: tritonapi}, funcs: [
+        function cmonKeyNotice(arg, next) {
+            console.log(wordwrap('Note: CMON uses authentication via ' +
+                'client TLS certiificates.\n'));
+            console.log(wordwrap('This action will create a ' +
+                'fresh private key to be written unencrypted to disk ' +
+                'in the current working directory. Copy these files to ' +
+                'your cmon client (whether Prometheus, or something ' +
+                'else).\n'));
+            console.log(wordwrap('This key will be usable only for CMON. ' +
+                'If your SSH key is removed from your account, this CMON ' +
+                'key will no longer work.\n'));
+            if (yes) {
+                next();
+                return;
+            } else {
+                console.log(wordwrap('If you do not specifically want to use ' +
+                    'CMON, or want to set this up later, you can answer ' +
+                    '"no" here.\n'));
+            }
+            common.promptYesNo({msg: 'Continue? [y/n] '}, function (answer) {
+                if (answer !== 'y') {
+                    console.error('Skipping CMON certificate generation (you ' +
+                        'can run "triton profile cmon-certgen" later).');
+                    next(true);
+                } else {
+                    console.log();
+                    next();
+                }
+            });
+        },
+
+        common.cliSetupTritonApi,
+
+        function checkCloudapiStatus(arg, next) {
+            tritonapi.cloudapi.ping({}, function (err, pong, res) {
+                if (!res) {
+                    next(new errors.SetupError(err, format(
+                        'error pinging CloudAPI <%s>', profile.url)));
+                } else if (res.statusCode === 503) {
+                    // TODO: Use maint res headers to estimate time back up.
+                    next(new errors.SetupError(err, format('CloudAPI <%s> is ',
+                        + 'in maintenance, please try again later',
+                        profile.url)));
+                } else if (res.statusCode === 200) {
+                    next();
+                } else {
+                    next(new errors.SetupError(err, format(
+                        'error pinging CloudAPI <%s>: %s status code',
+                        profile.url, res.statusCode)));
+                }
+            });
+        },
+
+        function checkForCmon(arg, next) {
+            tritonapi.cloudapi.listServices({}, function (err, svcs, res) {
+                if (!res) {
+                    next(new errors.SetupError(err, format(
+                        'could not list services on cloudapi %s',
+                        profile.url)));
+                } else if (res.statusCode === 401) {
+                    var portalUrl = portalUrlFromCloudapiUrl(profile.url);
+                    if (portalUrl) {
+                        next(new errors.SetupError(err, format(
+                            'invalid credentials. Visit <%s> to create the '
+                            + '"%s" account and/or add your SSH public key',
+                            portalUrl, profile.account)));
+                    } else {
+                        next(new errors.SetupError(err, format(
+                            'invalid credentials. You must create the '
+                            + '"%s" account and/or add your SSH public key',
+                            profile.account)));
+                    }
+                } else if (res.statusCode === 200) {
+                    if (svcs.cmon) {
+                        cmonHost = svcs.cmon;
+                        log.trace({cmonHost: cmonHost},
+                            'profileCmonSetup: checkForCmonService');
+                        next();
+                    } else {
+                        next(new errors.SetupError(err, format(
+                            'no "cmon" service on this datacenter',
+                            profile.url)));
+                    }
+                } else {
+                    // TODO: If this doesn't show res details, add that.
+                    next(new errors.SetupError(err, format(
+                        'unexpected response from cloudapi %s: %s status code',
+                        profile.url, res.statusCode)));
+                }
+            });
+        },
+
+        function mentionSettingUp(arg, next) {
+            console.log('Generating CMON certificates for profile "%s".',
+                profile.name);
+            next();
+        },
+
+        function getSigningKey(arg, next) {
+            var keyId = profile.keyId;
+            var keyFp = sshpk.parseFingerprint(keyId);
+            agent.listKeys(function (err, keys) {
+                if (err) {
+                    next(err);
+                    return;
+                }
+
+                arg.certSignKey = keys.filter(function (k) {
+                    return (keyFp.matches(k));
+                })[0];
+
+                if (!arg.certSignKey) {
+                    next(err);
+                    return;
+                }
+                next();
+            });
+        },
+
+        function generateAndSignCert(arg, next) {
+            var account = profile.account;
+            var fp = sshpk.parseFingerprint(profile.keyId);
+            var subj = sshpk.identityFromDN('CN=' + account);
+            var issuer = sshpk.identityFromDN('CN=' + fp);
+            var certSignKey = arg.certSignKey;
+
+            sslKey = sshpk.generatePrivateKey('ecdsa');
+
+            var certOpts = {
+                lifetime: 24*3600*opts.lifetime,
+                purposes: ['signature', 'identity', 'clientAuth', 'joyentCmon']
+            };
+
+            agent.createCertificate(subj, sslKey, issuer, certSignKey,
+                certOpts, function (err, cert) {
+                    if (err) {
+                        next(err);
+                        return;
+                    }
+                    sslCert = cert;
+                    next();
+            });
+        },
+
+        function writeFiles(arg, next) {
+            var fnStub = 'cmon-' + profile.account;
+            fs.writeFileSync(fnStub + '-key.pem', sslKey.toString('pem'));
+            fs.writeFileSync(fnStub + '-cert.pem', sslCert.toString('pem'));
+            next();
+        }
+    ]}, function (err) {
+        tritonapi.close();
+
+        if (err === true) { // Early-abort signal.
+            err = null;
+        }
+        if (err && !cmonHost) {
+            console.error('Warning: Error determining ' +
+                'if CloudAPI "%s" provides a CMON service:\n    %s',
+                profile.url, err);
+            err = null;
+        }
+
+        cb(err);
+    });
+}
+
+/**
  * Setup the given profile for Docker usage. This means checking the cloudapi
  * has a Docker service (ListServices), finding the user's SSH *private* key,
  * creating the client certs that will be used to talk to the Triton Docker
@@ -162,7 +371,7 @@ function profileDockerSetup(opts, cb) {
 
     /* Default to a 10 year certificate. */
     if (!opts.lifetime)
-        opts.lifetime = 3650;
+        opts.lifetime = DEFAULT_LIFETIME;
 
     var cli = opts.cli;
     var tritonapi = cli.tritonapiFromProfileName({profileName: opts.name});
@@ -589,5 +798,6 @@ function profileDockerSetup(opts, cb) {
 
 module.exports = {
     setCurrentProfile: setCurrentProfile,
+    profileCmonCertgen: profileCmonCertgen,
     profileDockerSetup: profileDockerSetup
 };

--- a/lib/do_profile/profilecommon.js
+++ b/lib/do_profile/profilecommon.js
@@ -300,10 +300,11 @@ function profileCmonCertgen(opts, cb) {
 
         function generateAndSignCert(arg, next) {
             var account = profile.account;
-            var fp = sshpk.parseFingerprint(profile.keyId);
+            var certSignKey = arg.certSignKey;
+
+            var fp = certSignKey.fingerprint('md5').toString('base64');
             var subj = sshpk.identityFromDN('CN=' + account);
             var issuer = sshpk.identityFromDN('CN=' + fp);
-            var certSignKey = arg.certSignKey;
 
             /*
              * Unlike Docker, where choosing ecdsa is somewhat arbitrary,


### PR DESCRIPTION
Fixes #294. This was adapted from @arekinath's [cmon-certgen](/arekinath/cmon-certgen).

Example usage:

```
> ./bin/triton profile cmon-certgen -t 1
Note: CMON uses authentication via client TLS certiificates.

This action will create a fresh private key to be written unencrypted to disk
in the current working directory. Copy these files to your cmon client
(whether Prometheus, or something else).

This key will be usable only for CMON. If your SSH key is removed from your
account, this CMON key will no longer work.

If you do not specifically want to use CMON, or want to set this up later,
you can answer "no" here.

Continue? [y/n] y

Generating CMON certificates for profile "env".
> openssl x509 -text -noout -in cmon-bbennett-cert.pem
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 1 (0x1)
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: CN = "SHA256:l1JcBkX5QbhfTeOI6RHriundohl/MXoZPlsgE+PVlPg"
        Validity
            Not Before: Apr 10 00:24:47 2020 GMT
            Not After : Apr 11 00:24:47 2020 GMT
        Subject: CN = bbennett
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:48:e0:12:f3:c6:d2:55:57:60:4c:ed:80:96:81:
                    a3:0f:2b:80:5b:61:b6:03:3e:5a:32:e2:d6:33:05:
                    99:30:65:b4:23:af:ba:dd:69:67:a9:20:77:ee:e6:
                    b6:94:3b:5f:fa:dc:0d:7d:03:23:c2:d9:bb:78:a7:
                    03:16:0b:e2:f8
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Key Usage: critical
                Digital Signature, Non Repudiation, Key Agreement
            X509v3 Extended Key Usage: critical
                TLS Web Client Authentication, 1.3.6.1.4.1.38678.1.4.2, TLS Web Server Authentication
            X509v3 Subject Alternative Name:
                DNS:bbennett
    Signature Algorithm: ecdsa-with-SHA256
         30:45:02:21:00:b8:d6:04:ce:0d:3f:a0:90:cd:d5:86:a8:1c:
         36:75:7a:53:e0:f6:e3:a3:04:67:88:2e:64:56:5c:cf:32:84:
         a0:02:20:07:1d:9f:97:87:b1:26:c5:6d:6a:0b:6f:60:09:ee:
         3d:59:c7:b6:ff:7f:1e:48:d0:dd:54:07:77:7e:e2:8a:68
>
```