### PR TITLE
added in sourcing alternate ssh port from instance tag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,14 @@ Known issues:
 
 ## not yet released
 
-- [TRITON-2182] make check fixes
+## 7.12.2
+
 - Add in sourcing from an instance tag an alternate port to ssh to for 
   circumstances where instances have ssh listening on a non-standard port.
+
+## 7.12.1
+
+- [TRITON-2182] make check fixes
 
 ## 7.12.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Known issues:
 ## not yet released
 
 - [TRITON-2182] make check fixes
+- Add in sourcing from an instance tag an alternate port to ssh to for 
+  circumstances where instances have ssh listening on a non-standard port.
 
 ## 7.12.0
 

--- a/lib/do_instance/do_ssh.js
+++ b/lib/do_instance/do_ssh.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2018, Joyent, Inc.
+ * Copyright (c) 2021, Joyent, Inc.
  *
  * `triton instance ssh ...`
  */

--- a/lib/do_instance/do_ssh.js
+++ b/lib/do_instance/do_ssh.js
@@ -26,6 +26,12 @@ var errors = require('../errors');
 var TAG_SSH_IP = 'tritoncli.ssh.ip';
 
 /*
+ * The tag "tritoncli.ssh.port may be set to a port number to indicate
+ * that ssh should connect there rather than the standard port 22.
+ */
+var TAG_SSH_PORT = 'tritoncli.ssh.port';
+
+/*
  * The tag "tritoncli.ssh.proxy" may be set to either the name or the UUID of
  * another instance in this account.  If set, we will use the "ProxyJump"
  * feature of SSH to tunnel through the SSH server on that host.  This is
@@ -41,7 +47,6 @@ var TAG_SSH_PROXY = 'tritoncli.ssh.proxy';
  * default user selection behaviour applies.
  */
 var TAG_SSH_PROXY_USER = 'tritoncli.ssh.proxyuser';
-
 
 function do_ssh(subcmd, opts, args, callback) {
     if (opts.help) {
@@ -208,6 +213,25 @@ function do_ssh(subcmd, opts, args, callback) {
             });
         },
 
+        function getPort(ctx, next) {
+            ctx.cli.tritonapi.getInstance(id, function (err, inst) {
+                if (err) {
+                    next(err);
+                    return;
+                }
+
+                ctx.inst = inst;
+
+                if (inst.tags && inst.tags[TAG_SSH_PORT]) {
+                    ctx.port = inst.tags[TAG_SSH_PORT];
+                } else {
+                    ctx.port = '22';
+                }
+
+                next();
+            });
+        },
+
         function getBastionUser(ctx, next) {
             if (!ctx.proxyImage || ctx.proxyUser) {
                 /*
@@ -265,6 +289,8 @@ function do_ssh(subcmd, opts, args, callback) {
                     '-o', 'ProxyJump=' + ctx.proxyUser + '@' + ctx.proxyIp
                 ].concat(args);
             }
+
+            args = ['-p', ctx.port].concat(args);
 
             /*
              * By default we disable ControlMaster (aka mux, aka SSH

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "triton",
   "description": "Joyent Triton CLI and client (https://www.joyent.com/triton)",
-  "version": "7.12.1",
+  "version": "7.12.2",
   "author": "Joyent (joyent.com)",
   "homepage": "https://github.com/joyent/node-triton",
   "dependencies": {


### PR DESCRIPTION
the tag is tritoncli.ssh.port which may be useful to other users than me for situations like when when ssh may be listening on a non-standard port.