### PR TITLE
joyent/node-triton#314 want act-as support for "triton profile docker-setup" and "triton profile cmon-certgen"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Known issues:
 
 ## not yet released
 
+- [node-triton#314] want act-as support for "triton profile docker-setup" and
+  "triton profile cmon-certgen"
+
 ## 7.14.0
 
 - [node-triton#311] Wrong CLI_CONFIG_DIR when XDG_CONFIG_HOME is set

--- a/lib/common.js
+++ b/lib/common.js
@@ -473,7 +473,10 @@ function profileSlug(o) {
     assert.string(o.url, 'o.url');
 
     var slug;
-    var account = o.account.replace(/[@]/g, '_');
+    var account = o.account;
+    if (o.actAsAccount)
+        account = o.actAsAccount;
+    account = account.replace(/[@]/g, '_');
     var url = o.url.replace(/^https?:\/\//, '');
     if (o.user) {
         var user = o.user.replace(/[@]/g, '_');

--- a/lib/do_profile/profilecommon.js
+++ b/lib/do_profile/profilecommon.js
@@ -299,8 +299,11 @@ function profileCmonCertgen(opts, cb) {
         },
 
         function generateAndSignCert(arg, next) {
-            var account = profile.account;
             var certSignKey = arg.certSignKey;
+
+            var account = profile.account;
+            if (profile.actAsAccount)
+                account = profile.actAsAccount;
 
             var fp = certSignKey.fingerprint('md5').toString('base64');
             var subj = sshpk.identityFromDN('CN=' + account);
@@ -330,7 +333,10 @@ function profileCmonCertgen(opts, cb) {
         },
 
         function writeFiles(arg, next) {
-            var fnStub = 'cmon-' + profile.account;
+            var account = profile.account;
+            if (profile.actAsAccount)
+                account = profile.actAsAccount;
+            var fnStub = 'cmon-' + account;
             fs.writeFileSync(fnStub + '-key.pem', sslKey.toString('pem'));
             fs.writeFileSync(fnStub + '-cert.pem', sslCert.toString('pem'));
             next();
@@ -582,7 +588,10 @@ function profileDockerSetup(opts, cb) {
              */
             arg.privKey = sshpk.generatePrivateKey('ecdsa');
 
-            var id = sshpk.identityFromDN('CN=' + profile.account);
+            var targetAcct = profile.account;
+            if (profile.actAsAccount)
+                targetAcct = profile.actAsAccount;
+            var id = sshpk.identityFromDN('CN=' + targetAcct);
             var parentId = sshpk.identityFromDN('CN=' +
                 pubKey.fingerprint('md5').toString('base64'));
             var serial = crypto.randomBytes(8);


### PR DESCRIPTION
Testing done:
 * ran `make check`
 * ran most of `make test` (we don't have everything set up on our testing triton to run all of it though)
 * added my user as a cross-account member of `otheracct`'s "administrator" role
 * ran `./bin/triton --act-as=otheracct profile docker-setup`
 * verified that `~/.triton/docker/otheracct@cloudapi_gps-1_uqcloud_net` is created
 * ran `openssl x509 -text -noout < ~/.triton/docker/otheracct@.../cert.pem` and verified that Subject is `CN = otheracct`
 * ran `eval "$(./bin/triton --act-as=otheracct env --docker env)"` and then `docker info`, checked for `SDCAccount: otheracct`
 * ran `./bin/triton --act-as=otheracct profile cmon-certgen`
 * ran `openssl x509` again to check the certificate subject
 * used a simple example config to verify that it can auth to CMON