### PR TITLE
node-triton#316 cmon-certgen should generate an example prometheus.yml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,11 @@ Known issues:
 
 ## not yet released
 
+## 7.15.0
+
 - [node-triton#314] want act-as support for "triton profile docker-setup" and
   "triton profile cmon-certgen"
+- [node-triton#316] cmon-certgen should generate an example prometheus.yml
 
 ## 7.14.0
 

--- a/lib/do_profile/profilecommon.js
+++ b/lib/do_profile/profilecommon.js
@@ -172,6 +172,7 @@ function profileCmonCertgen(opts, cb) {
 
     var profile = tritonapi.profile;
     var cmonHost;
+    var configYml;
 
     var agent = new sshpk_agent.Client();
     var sslCert;
@@ -332,6 +333,39 @@ function profileCmonCertgen(opts, cb) {
             });
         },
 
+        function generateExampleConfig(arg, next) {
+            var account = profile.account;
+            if (profile.actAsAccount)
+                account = profile.actAsAccount;
+            var fnStub = 'cmon-' + account;
+            var hostname = mod_url.parse(cmonHost).hostname;
+            configYml = '\
+global:\n\
+    scrape_interval: 15s\n\
+    scrape_timeout: 10s\n\
+    evaluation_interval: 15s\n\
+scrape_configs:\n\
+    - job_name: triton-' + account + '\n\
+      scheme: https\n\
+      tls_config:\n\
+          cert_file: ' + fnStub + '-cert.pem\n\
+          key_file: ' + fnStub + '-key.pem\n\
+      relabel_configs:\n\
+          - source_labels: [__meta_triton_machine_alias]\n\
+            target_label: alias\n\
+          - source_labels: [__meta_triton_machine_id]\n\
+            target_label: instance\n\
+      triton_sd_configs:\n\
+          - account: ' + account + '\n\
+            dns_suffix: ' + hostname + '\n\
+            endpoint: ' + hostname + '\n\
+            version: 1\n\
+            tls_config:\n\
+                cert_file: ' + fnStub + '-cert.pem\n\
+                key_file: ' + fnStub + '-key.pem\n';
+            next();
+        },
+
         function writeFiles(arg, next) {
             var account = profile.account;
             if (profile.actAsAccount)
@@ -339,6 +373,19 @@ function profileCmonCertgen(opts, cb) {
             var fnStub = 'cmon-' + account;
             fs.writeFileSync(fnStub + '-key.pem', sslKey.toString('pem'));
             fs.writeFileSync(fnStub + '-cert.pem', sslCert.toString('pem'));
+            fs.writeFileSync(fnStub + '-prometheus.yml', configYml);
+            next();
+        },
+
+        function mentionFiles(arg, next) {
+            var fnStub = 'cmon-' + profile.account;
+            console.log('\nCMON authentication certificate and key have been ' +
+                'placed in files\n"%s" and "%s".', fnStub + '-cert.pem',
+                fnStub + '-key.pem');
+            console.log('\nAn example Prometheus configuration file has also ' +
+                'been written into\n"%s".', fnStub + '-prometheus.yml');
+            console.log('\nIt can be used as-is for testing by running\n  ' +
+                '"prometheus --config.file=%s"', fnStub + '-prometheus.yml');
             next();
         }
     ]}, function (err) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "triton",
   "description": "Joyent Triton CLI and client (https://www.joyent.com/triton)",
-  "version": "7.14.0",
+  "version": "7.15.0",
   "author": "Joyent (joyent.com)",
   "homepage": "https://github.com/joyent/node-triton",
   "dependencies": {


### PR DESCRIPTION
Testing done:
 * ran `make check`
 * ran `triton profile cmon-certgen`, new output below
 * ran `prometheus --config.file=cmon-xlex-prometheus.yml` to verify generated config works and authenticates with the generated key and cert

```
$ ./bin/triton profile cmon-certgen
Note: CMON uses authentication via client TLS certiificates.

This action will create a fresh private key which is written unencrypted to
disk in the current working directory. Copy these files to your cmon client
(whether Prometheus, or something else).

This key will be usable only for CMON. If your SSH key is removed from your
account, this CMON key will no longer work.

If you do not specifically want to use CMON, or want to set this up later,
you can answer "no" here.

Continue? [y/n] y

Generating CMON certificates for profile "env".

CMON authentication certificate and key have been placed in files
"cmon-xlex-cert.pem" and "cmon-xlex-key.pem".

An example Prometheus configuration file has also been written into
"cmon-xlex-prometheus.yml".

It can be used as-is for testing by running
  "prometheus --config.file=cmon-xlex-prometheus.yml"
```

The example config file:

```
global:
    scrape_interval: 15s
    scrape_timeout: 10s
    evaluation_interval: 15s
scrape_configs:
    - job_name: triton-xlex
      scheme: https
      tls_config:
          cert_file: cmon-xlex-cert.pem
          key_file: cmon-xlex-key.pem
      relabel_configs:
          - source_labels: [__meta_triton_machine_alias]
            target_label: alias
          - source_labels: [__meta_triton_machine_id]
            target_label: instance
      triton_sd_configs:
          - account: xlex
            dns_suffix: cmon.uqcloud.net
            endpoint: cmon.uqcloud.net
            version: 1
            tls_config:
                cert_file: cmon-xlex-cert.pem
                key_file: cmon-xlex-key.pem
```