### PR TITLE
joyent/node-triton#318 want --primary argument to "triton inst nic create"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Known issues:
 - [node-triton#314] want act-as support for "triton profile docker-setup" and
   "triton profile cmon-certgen"
 - [node-triton#316] cmon-certgen should generate an example prometheus.yml
+- [node-triton#318] want --primary argument to "triton inst nic create"
 
 ## 7.14.0
 

--- a/lib/cloudapi2.js
+++ b/lib/cloudapi2.js
@@ -2304,7 +2304,8 @@ function addNic(opts, cb) {
     assert.ok(opts.network, 'opts.network');
 
     var data = {
-        network: opts.network
+        network: opts.network,
+        primary: opts.primary
     };
 
     this._request({

--- a/lib/do_instance/do_nic/do_create.js
+++ b/lib/do_instance/do_nic/do_create.js
@@ -19,6 +19,7 @@ function do_create(subcmd, opts, args, cb) {
     assert.optionalBool(opts.wait, 'opts.wait');
     assert.optionalBool(opts.json, 'opts.json');
     assert.optionalBool(opts.help, 'opts.help');
+    assert.optionalBool(opts.primary, 'opts.primary');
     assert.func(cb, 'cb');
 
     if (opts.help) {
@@ -72,12 +73,14 @@ function do_create(subcmd, opts, args, cb) {
 
         createOpts.id = regularArgs[0];
         createOpts.network = netObj;
+        createOpts.primary = (opts.primary === true);
     } else {
         assert.array(args, 'args');
         assert.equal(args.length, 2, 'INST and NETWORK');
 
         createOpts.id = args[0];
         createOpts.network = args[1];
+        createOpts.primary = (opts.primary === true);
     }
 
     function wait(instId, mac, next) {
@@ -171,6 +174,11 @@ do_create.options = [
         names: ['wait', 'w'],
         type: 'bool',
         help: 'Wait for the creation to complete.'
+    },
+    {
+        names: ['primary', 'p'],
+        type: 'bool',
+        help: 'Make new NIC the primary NIC for the instance'
     }
 ];
 

--- a/lib/tritonapi.js
+++ b/lib/tritonapi.js
@@ -2616,7 +2616,8 @@ function addNic(opts, cb) {
     pipeline.push(function createNic(arg, next) {
         self.cloudapi.addNic({
             id: arg.instId,
-            network: arg.netId || arg.network
+            network: arg.netId || arg.network,
+            primary: arg.primary
         }, function onCreateNic(err, _nic, _res) {
             res = _res;
             res.instId = arg.instId; // gross hack, in case caller needs it
@@ -2629,7 +2630,8 @@ function addNic(opts, cb) {
     var pipelineArg = {
         client: self,
         id: opts.id,
-        network: opts.network
+        network: opts.network,
+        primary: opts.primary
     };
 
     vasync.pipeline({


### PR DESCRIPTION
testing done:
 * ran `make check`
 * tested against an updated cloudapi
 * did `triton inst nic create foobar fabric`, checked `primary` flag not set (just looked on adminui)
 * `triton inst nic create --primary foobar fabric2`, checked adminui again, primary flag set

This PR includes #314 and #316 since the requested changelog updates conflict otherwise. Let me know if you'd rather them all based off master instead (I'll just have to rebase each one by one after the prior one goes in)