### PR TITLE
Allow spaces in the SSH ControlPath

### DIFF
--- a/lib/do_instance/do_ssh.js
+++ b/lib/do_instance/do_ssh.js
@@ -313,7 +313,7 @@ function do_ssh(subcmd, opts, args, callback) {
                     'nullSshControlPath');
                 args = [
                     '-o', 'ControlMaster=no',
-                    '-o', 'ControlPath='+nullSshControlPath
+                    '-o', 'ControlPath="' + nullSshControlPath + '"'
                 ].concat(args);
             }
 


### PR DESCRIPTION
This addresses https://github.com/TritonDataCenter/node-triton/issues/240