### PR TITLE
RFD 189: Console Access - Add console command to CLI

### DIFF
--- a/lib/cloudapi2.js
+++ b/lib/cloudapi2.js
@@ -1370,6 +1370,11 @@ CloudApi.prototype.getMachineVnc = function getMachineVnc(uuid, cb) {
     this._createWebSocket({path: endpoint}, cb);
 };
 
+CloudApi.prototype.getMachineConsole = function getMachineConsole(uuid, cb) {
+    var endpoint = format('/%s/machines/%s/console', this.account, uuid);
+    this._createWebSocket({path: endpoint}, cb);
+};
+
 /**
  * resize a machine by id.
  *

--- a/lib/do_instance/do_console.js
+++ b/lib/do_instance/do_console.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2025 Joyent, Inc.
+ * Copyright 2026 Edgecast Cloud LLC.
  *
  * `triton instance console ...`
  */
@@ -92,18 +92,19 @@ function do_console(subcmd, opts, args, callback) {
                 callback();
             });
 
-            // Handle process signals
-            process.on('SIGINT', function () {
+            // Handle process signals (store refs for cleanup)
+            var sigintHandler = function () {
                 console.log('\n[Interrupted]');
                 cleanup();
                 callback();
-            });
-
-            process.on('SIGTERM', function () {
+            };
+            var sigtermHandler = function () {
                 console.log('\n[Terminated]');
                 cleanup();
                 callback();
-            });
+            };
+            process.on('SIGINT', sigintHandler);
+            process.on('SIGTERM', sigtermHandler);
 
             function cleanup() {
                 // Restore stdin mode
@@ -123,6 +124,10 @@ function do_console(subcmd, opts, args, callback) {
                 // Remove stdin listeners
                 process.stdin.removeAllListeners('data');
                 process.stdin.pause();
+
+                // Remove signal handlers to prevent memory leaks
+                process.removeListener('SIGINT', sigintHandler);
+                process.removeListener('SIGTERM', sigtermHandler);
             }
         });
     });

--- a/lib/do_instance/do_console.js
+++ b/lib/do_instance/do_console.js
@@ -26,7 +26,6 @@ function do_console(subcmd, opts, args, callback) {
     var id = args.shift();
     var tritonapi = this.top.tritonapi;
     var stdinWasRaw = false;
-    var stdinOldMode;
 
     common.cliSetupTritonApi({cli: this.top}, function onSetup(setupErr) {
         if (setupErr) {
@@ -45,7 +44,6 @@ function do_console(subcmd, opts, args, callback) {
             // Put stdin in raw mode if it's a TTY
             if (tty.isatty(process.stdin.fd)) {
                 stdinWasRaw = process.stdin.isRaw;
-                stdinOldMode = process.stdin.setRawMode;
                 process.stdin.setRawMode(true);
                 process.stdin.resume();
             }

--- a/lib/do_instance/do_console.js
+++ b/lib/do_instance/do_console.js
@@ -1,0 +1,164 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2025 Joyent, Inc.
+ *
+ * `triton instance console ...`
+ */
+
+var tty = require('tty');
+var common = require('../common');
+var errors = require('../errors');
+
+function do_console(subcmd, opts, args, callback) {
+    if (opts.help) {
+        this.do_help('help', {}, [subcmd], callback);
+        return;
+    } else if (args.length === 0) {
+        callback(new errors.UsageError('missing INST arg'));
+        return;
+    }
+
+    var id = args.shift();
+    var tritonapi = this.top.tritonapi;
+    var stdinWasRaw = false;
+    var stdinOldMode;
+
+    common.cliSetupTritonApi({cli: this.top}, function onSetup(setupErr) {
+        if (setupErr) {
+            callback(setupErr);
+            return;
+        }
+
+        console.log('Connecting to console... (Ctrl-] to disconnect)');
+
+        tritonapi.getInstanceConsole(id, function consoleCb(consoleErr, shed) {
+            if (consoleErr) {
+                callback(consoleErr);
+                return;
+            }
+
+            // Put stdin in raw mode if it's a TTY
+            if (tty.isatty(process.stdin.fd)) {
+                stdinWasRaw = process.stdin.isRaw;
+                stdinOldMode = process.stdin.setRawMode;
+                process.stdin.setRawMode(true);
+                process.stdin.resume();
+            }
+
+            // Disable stdout buffering
+            if (process.stdout._handle && process.stdout._handle.setBlocking) {
+                process.stdout._handle.setBlocking(true);
+            }
+
+            // Forward stdin to WebSocket
+            process.stdin.on('data', function (data) {
+                // Check for escape sequence: Ctrl-] (ASCII 0x1d)
+                if (data.length === 1 && data[0] === 0x1d) {
+                    console.log('\n[Disconnecting...]');
+                    cleanup();
+                    callback();
+                    return;
+                }
+                shed.send(data);
+            });
+
+            // Forward WebSocket to stdout
+            shed.on('binary', function (data) {
+                process.stdout.write(data);
+            });
+
+            shed.on('text', function (text) {
+                process.stdout.write(text);
+            });
+
+            shed.on('end', function (code, reason) {
+                console.log('\n[Console connection closed]');
+                cleanup();
+                callback();
+            });
+
+            shed.on('error', function (shedErr) {
+                console.error('\n[Console error: ' + shedErr.message + ']');
+                cleanup();
+                callback(shedErr);
+            });
+
+            shed.on('connectionReset', function () {
+                console.log('\n[Connection reset by peer]');
+                cleanup();
+                callback();
+            });
+
+            // Handle process signals
+            process.on('SIGINT', function () {
+                console.log('\n[Interrupted]');
+                cleanup();
+                callback();
+            });
+
+            process.on('SIGTERM', function () {
+                console.log('\n[Terminated]');
+                cleanup();
+                callback();
+            });
+
+            function cleanup() {
+                // Restore stdin mode
+                if (stdinWasRaw !== undefined && process.stdin.setRawMode) {
+                    process.stdin.setRawMode(stdinWasRaw);
+                }
+
+                // Close WebSocket
+                if (shed && !shed.destroyed) {
+                    try {
+                        shed.end();
+                    } catch (e) {
+                        // Ignore errors during cleanup
+                    }
+                }
+
+                // Remove stdin listeners
+                process.stdin.removeAllListeners('data');
+                process.stdin.pause();
+            }
+        });
+    });
+}
+
+do_console.options = [
+    {
+        names: ['help', 'h'],
+        type: 'bool',
+        help: 'Show this help.'
+    }
+];
+
+do_console.synopses = ['{{name}} console [OPTIONS] INST'];
+do_console.help = [
+    'Connect to instance console.',
+    '',
+    '{{usage}}',
+    '',
+    '{{options}}',
+    '',
+    'Connect to the serial console (for KVM instances) or zone console',
+    '(for other instance types). This provides low-level access to the',
+    'instance, useful for troubleshooting boot issues or network problems.',
+    '',
+    'Press Ctrl-] to disconnect from the console.',
+    '',
+    'Where INST is an instance name, id, or short id.',
+    '',
+    'Note: Not all instance types support console access. KVM and Bhyve',
+    'instances provide serial console access. SmartOS containers provide',
+    'zone console access.'
+].join('\n');
+
+do_console.completionArgtypes = ['tritoninstance', 'none'];
+
+module.exports = do_console;

--- a/lib/do_instance/do_console.js
+++ b/lib/do_instance/do_console.js
@@ -107,7 +107,7 @@ function do_console(subcmd, opts, args, callback) {
 
             function cleanup() {
                 // Restore stdin mode
-                if (stdinWasRaw !== undefined && process.stdin.setRawMode) {
+                if (tty.isatty(process.stdin.fd) && process.stdin.setRawMode) {
                     process.stdin.setRawMode(stdinWasRaw);
                 }
 

--- a/lib/do_instance/index.js
+++ b/lib/do_instance/index.js
@@ -50,6 +50,7 @@ function InstanceCLI(top) {
             'disable-deletion-protection',
             { group: '' },
             'ssh',
+            'console',
             'vnc',
             'ip',
             'wait',
@@ -92,6 +93,7 @@ InstanceCLI.prototype.do_disable_deletion_protection =
     require('./do_disable_deletion_protection');
 
 InstanceCLI.prototype.do_ssh = require('./do_ssh');
+InstanceCLI.prototype.do_console = require('./do_console');
 InstanceCLI.prototype.do_vnc = require('./do_vnc');
 InstanceCLI.prototype.do_ip = require('./do_ip');
 InstanceCLI.prototype.do_wait = require('./do_wait');

--- a/lib/tritonapi.js
+++ b/lib/tritonapi.js
@@ -1659,6 +1659,34 @@ TritonApi.prototype.getInstanceVnc = function getInstanceVnc(id, cb) {
     });
 };
 
+TritonApi.prototype.getInstanceConsole = function getInstanceConsole(id, cb) {
+    assert.string(id, 'id');
+    assert.func(cb, 'cb');
+
+    var self = this;
+    var shed = null;
+
+    vasync.pipeline({arg: {client: self, id: id}, funcs: [
+        _stepInstId,
+        function getConsoleConnection(arg, next) {
+            self.cloudapi.getMachineConsole(arg.instId, function (err, shed_, _) {
+                if (err) {
+                    next(err);
+                    return;
+                }
+                shed = shed_;
+                next();
+            });
+        }
+    ]}, function vasyncCb(err) {
+        if (err) {
+            cb(err, null);
+        } else {
+            cb(null, shed);
+        }
+    });
+};
+
 // ---- instance enable/disable firewall
 
 /**


### PR DESCRIPTION
Add `triton instance console` command for terminal-based console access.

Changes:
- Add lib/do_instance/do_console.js - CLI command implementation
- Add getInstanceConsole() to tritonapi.js
- Add getMachineConsole() to cloudapi2.js
- Register console command in do_instance/index.js

Usage:
  triton instance console <instance-id> triton inst console <instance-id>

Features:
- Direct terminal integration (raw mode)
- Bidirectional byte stream
- Ctrl-] to disconnect (same as vmadm console)
- Works with all instance types (KVM, Bhyve, Joyent, LX)

The command connects stdin/stdout directly to the WebSocket for a native terminal experience. Useful for boot debugging, network troubleshooting, and low-level instance access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)