### PR TITLE
MANTA-5526 triton cli should be able to pass bucket scope when creating new access keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,16 @@ Known issues:
 
 - No changes yet
 
+## 7.19.0
+
+- Support per-bucket access-key scope in the CLI. `triton accesskey create`
+  and `triton rbac accesskey --create` accept `--scope=JSON|@FILE`. For
+  updates, `triton accesskey update` accepts the inline `scope=...`
+  KEY=VALUE form and `-f JSON-FILE`; `triton rbac accesskey --update`
+  accepts `--scope=JSON|@FILE`. Both update commands also accept a new
+  `--remove-scope` flag that clears the scope. `accesskey get` and
+  `accesskey list` now surface the parsed envelope under `-l`.
+
 ## 7.18.0
 
 - TRITON-2510 Add `triton accesskeys` and `triton rbac accesskey` commands

--- a/lib/cloudapi2.js
+++ b/lib/cloudapi2.js
@@ -932,6 +932,11 @@ CloudApi.prototype.listAccessKeys = function listAccessKeys(opts, cb) {
  * @param {Object} opts Optional payload.
  *      - {String} status: Optional.
  *      - {String} description: Optional.
+ *      - {Object} scope: Optional bucket-scope envelope of the form
+ *           { version: 1, permissions: [{bucket, level}, ...] }
+ *        Omit / null for an unrestricted key. CloudAPI validates the
+ *        envelope server-side and returns InvalidArgumentError on
+ *        malformed input.
  * @param {Function} cb `function (err, accesskey, res)`
  */
 CloudApi.prototype.createAccessKey = function createAccessKey(opts, cb) {
@@ -975,7 +980,11 @@ CloudApi.prototype.deleteAccessKey = function deleteAccessKey(opts, cb) {
 // <updatable account field> -> <expected typeof>
 CloudApi.prototype.UPDATE_ACCESSKEY_FIELDS = {
     status: 'string',
-    description: 'string'
+    description: 'string',
+    // scope: object envelope to set, or null/empty to clear (make key
+    // unrestricted). typeof null === 'object' so the validateObject('object')
+    // check passes for both cases.
+    scope: 'object'
 };
 
 /**
@@ -992,6 +1001,9 @@ CloudApi.prototype.updateAccessKey = function updateAccessKey(opts, cb) {
     assert.string(opts.accessKeyId, 'opts.accessKeyId');
     assert.optionalString(opts.status, 'opts.status');
     assert.optionalString(opts.description, 'opts.description');
+    // opts.scope may be: undefined (no change), null/'' (clear scope),
+    // or an object { version, permissions: [...] }. We do not assert
+    // shape — CloudAPI is the source of truth for scope validation.
     assert.func(cb, 'cb');
 
     var data = {};
@@ -1034,6 +1046,8 @@ CloudApi.prototype.getAccessKey = function getAccessKey(opts, cb) {
  *      - {String} userId: Required.
  *      - {String} status: Optional.
  *      - {String} description: Optional.
+ *      - {Object} scope: Optional bucket-scope envelope; see
+ *        createAccessKey for shape. Omit / null for unrestricted.
  * @param {Function} cb `function (err, accesskey, res)`
  */
 CloudApi.prototype.createUserAccessKey =
@@ -1128,6 +1142,7 @@ CloudApi.prototype.updateUserAccessKey =
     assert.string(opts.userId, 'opts.userId');
     assert.optionalString(opts.status, 'opts.status');
     assert.optionalString(opts.description, 'opts.description');
+    // See updateAccessKey for scope semantics.
     assert.func(cb, 'cb');
 
     var data = {};

--- a/lib/do_accesskey/do_create.js
+++ b/lib/do_accesskey/do_create.js
@@ -11,13 +11,14 @@
  */
 
 var assert = require('assert-plus');
+var fs = require('fs');
 var tabula = require('tabula');
 
 var common = require('../common');
 var errors = require('../errors');
 
 var COLUMNS_DEFAULT = 'accesskeyid,accesskeysecret';
-var COLUMNS_LONG = 'accesskeyid,status,credentialtype,description,created,updated,expiration';
+var COLUMNS_LONG = 'accesskeyid,status,credentialtype,description,created,updated,expiration,scope';
 
 function do_create(subcmd, opts, args, cb) {
     assert.func(cb, 'cb');
@@ -42,6 +43,26 @@ function do_create(subcmd, opts, args, cb) {
 
     if (opts.description) {
         params.description = opts.description;
+    }
+
+    if (opts.scope) {
+        var raw = opts.scope;
+        if (raw[0] === '@') {
+            try {
+                raw = fs.readFileSync(raw.slice(1), 'utf8');
+            } catch (e) {
+                cb(new errors.UsageError(
+                    'cannot read --scope file: ' + e.message));
+                return;
+            }
+        }
+        try {
+            params.scope = JSON.parse(raw);
+        } catch (e) {
+            cb(new errors.UsageError(
+                '--scope is not valid JSON: ' + e.message));
+            return;
+        }
     }
 
     common.cliSetupTritonApi({cli: this.top}, function onSetup(err) {
@@ -77,6 +98,15 @@ function do_create(subcmd, opts, args, cb) {
                     if (opts.description) {
                         columns.push('description');
                     }
+
+                    if (opts.scope) {
+                        columns.push('scope');
+                    }
+                }
+
+                if (accessKey.scope &&
+                  typeof (accessKey.scope) === 'object') {
+                    accessKey.scope = JSON.stringify(accessKey.scope);
                 }
 
                 tabula([accessKey], {
@@ -102,6 +132,16 @@ do_create.options = [
         type: 'string',
         helpArg: 'DESC',
         help: 'A short description for the access key.'
+    },
+    {
+        names: ['scope'],
+        type: 'string',
+        helpArg: 'JSON|@FILE',
+        help: 'Per-bucket scope envelope as JSON, or "@path" to read from ' +
+              'a file. Example:\n' +
+              '  --scope=\'{"version":1,"permissions":' +
+              '[{"bucket":"logs-*","level":"read"}]}\'\n' +
+              'Omit for an unrestricted key.'
     },
     {
         names: ['status', 's'],

--- a/lib/do_accesskey/do_get.js
+++ b/lib/do_accesskey/do_get.js
@@ -17,7 +17,7 @@ var common = require('../common');
 var errors = require('../errors');
 
 var COLUMNS_DEFAULT = 'accesskeyid,status,credentialtype,updated';
-var COLUMNS_LONG = 'accesskeyid,status,credentialtype,description,created,updated,expiration';
+var COLUMNS_LONG = 'accesskeyid,status,credentialtype,description,created,updated,expiration,scope';
 
 function do_get(subcmd, opts, args, cb) {
     assert.func(cb, 'cb');
@@ -55,6 +55,11 @@ function do_get(subcmd, opts, args, cb) {
             if (opts.json) {
                 console.log(JSON.stringify(accessKey));
             } else {
+                if (accessKey.scope &&
+                  typeof (accessKey.scope) === 'object') {
+                    accessKey.scope = JSON.stringify(accessKey.scope);
+                }
+
                 var columns = opts.long ? COLUMNS_LONG : COLUMNS_DEFAULT;
                 if (opts.o) {
                     columns = opts.o.toLowerCase();

--- a/lib/do_accesskey/do_list.js
+++ b/lib/do_accesskey/do_list.js
@@ -18,7 +18,7 @@ var errors = require('../errors');
 
 
 var COLUMNS_DEFAULT = 'accesskeyid,status,credentialtype,updated';
-var COLUMNS_LONG = 'accesskeyid,status,credentialtype,description,created,updated,expiration';
+var COLUMNS_LONG = 'accesskeyid,status,credentialtype,description,created,updated,expiration,scope';
 var SORT_DEFAULT = 'created';
 
 
@@ -54,6 +54,12 @@ function do_list(subcmd, opts, args, cb) {
             if (opts.json) {
                 common.jsonStream(keys);
             } else {
+                keys.forEach(function (k) {
+                  if (k.scope && typeof (k.scope) === 'object') {
+                        k.scope = JSON.stringify(k.scope);
+                    }
+                });
+
                 var columns = opts.long ? COLUMNS_LONG : COLUMNS_DEFAULT;
                 if (opts.o) {
                     columns = opts.o.toLowerCase();

--- a/lib/do_accesskey/do_update.js
+++ b/lib/do_accesskey/do_update.js
@@ -57,6 +57,13 @@ function do_update(subcmd, opts, args, cb) {
                 return;
             }
 
+            if (opts.remove_scope) {
+                // Sending null tells CloudAPI to remove the scope and
+                // make the key unrestricted again. See sdc-cloudapi
+                // lib/endpoints/accesskeys.js update().
+                ctx.data.scope = null;
+            }
+
             next();
         },
 
@@ -144,6 +151,11 @@ do_update.options = [
         helpArg: 'JSON-FILE',
         help: 'A file holding a JSON file of updates, or "-" to read ' +
             'JSON from stdin.'
+    },
+    {
+        names: ['remove-scope'],
+        type: 'bool',
+        help: 'Remove the per-bucket scope, making this key unrestricted.'
     }
 ];
 
@@ -171,7 +183,14 @@ do_update.help = [
     'Updateable fields:',
     '    ' + Object.keys(UPDATE_ACCESSKEY_FIELDS).sort().map(function (f) {
         return f + ' (' + UPDATE_ACCESSKEY_FIELDS[f] + ')';
-    }).join('\n    ')
+    }).join('\n    '),
+    '',
+    'Examples:',
+    '    triton accesskey update KEY status=Active',
+    '    triton accesskey update KEY \\',
+    '        scope=\'{"version":1,"permissions":' +
+        '[{"bucket":"logs-*","level":"read"}]}\'',
+    '    triton accesskey update --remove-scope KEY'
 ].join('\n');
 
 module.exports = do_update;

--- a/lib/do_rbac/do_accesskey.js
+++ b/lib/do_rbac/do_accesskey.js
@@ -22,7 +22,7 @@ var common = require('../common');
 var errors = require('../errors');
 
 var COLUMNS_DEFAULT = 'accesskeyid,status,created';
-var COLUMNS_LONG = 'accesskeyid,status,description,created,updated';
+var COLUMNS_LONG = 'accesskeyid,status,description,created,updated,scope';
 
 function _getUserAccessKey(opts, cb) {
     assert.object(opts.cli, 'opts.cli');
@@ -53,6 +53,11 @@ function _getUserAccessKey(opts, cb) {
             if (opts.json) {
                 console.log(JSON.stringify(accessKey));
             } else {
+                if (accessKey.scope &&
+                    typeof accessKey.scope === 'object') {
+                    accessKey.scope = JSON.stringify(accessKey.scope);
+                }
+
                 var columns = opts.long ? COLUMNS_LONG : COLUMNS_DEFAULT;
                 if (opts.o) {
                     columns = opts.o.toLowerCase();
@@ -152,6 +157,26 @@ function _createUserAccessKey(opts, cb) {
         params.description = opts.description;
     }
 
+    if (opts.scope) {
+        var raw = opts.scope;
+        if (raw[0] === '@') {
+            try {
+                raw = fs.readFileSync(raw.slice(1), 'utf8');
+            } catch (e) {
+                cb(new errors.UsageError(
+                    'cannot read --scope file: ' + e.message));
+                return;
+            }
+        }
+        try {
+            params.scope = JSON.parse(raw);
+        } catch (e) {
+            cb(new errors.UsageError(
+                '--scope is not valid JSON: ' + e.message));
+            return;
+        }
+    }
+
     common.cliSetupTritonApi({cli: opts.cli}, function onSetup(err) {
         if (err) {
             cb(err);
@@ -199,6 +224,29 @@ function _updateUserAccessKey(opts, cb) {
 
     if (opts.description) {
         params.description = opts.description;
+    }
+
+    if (opts.remove_scope) {
+        // Sending null tells CloudAPI to remove the scope.
+        params.scope = null;
+    } else if (opts.scope) {
+        var raw = opts.scope;
+        if (raw[0] === '@') {
+            try {
+                raw = fs.readFileSync(raw.slice(1), 'utf8');
+            } catch (e) {
+                cb(new errors.UsageError(
+                    'cannot read --scope file: ' + e.message));
+                return;
+            }
+        }
+        try {
+            params.scope = JSON.parse(raw);
+        } catch (e) {
+            cb(new errors.UsageError(
+                '--scope is not valid JSON: ' + e.message));
+            return;
+        }
     }
 
     common.cliSetupTritonApi({cli: opts.cli}, function onSetup(err) {
@@ -323,6 +371,7 @@ function do_accesskey(subcmd, opts, args, cb) {
             cli: this.top,
             status: opts.status,
             description: opts.description,
+            scope: opts.scope,
             userId: args[0],
             json: opts.json
         }, cb);
@@ -332,6 +381,8 @@ function do_accesskey(subcmd, opts, args, cb) {
             cli: this.top,
             status: opts.status,
             description: opts.description,
+            scope: opts.scope,
+            remove_scope: opts.remove_scope,
             userId: args[0],
             accessKeyId: args[1],
             json: opts.json
@@ -385,6 +436,22 @@ do_accesskey.options = [
         type: 'string',
         helpArg: 'STATUS',
         help: 'Status for the access key'
+    },
+    {
+        names: ['scope'],
+        type: 'string',
+        helpArg: 'JSON|@FILE',
+        help: 'Per-bucket scope envelope as JSON, or "@path" to read ' +
+              'from a file. Example:\n' +
+              '  --scope=\'{"version":1,"permissions":' +
+              '[{"bucket":"logs-*","level":"read"}]}\'\n' +
+              'Omit for an unrestricted key.'
+    },
+    {
+        names: ['remove-scope'],
+        type: 'bool',
+        help: 'On --update, remove the per-bucket scope (make this key ' +
+              'unrestricted).'
     },
     {
         group: 'Action Options'

--- a/lib/do_rbac/do_accesskeys.js
+++ b/lib/do_rbac/do_accesskeys.js
@@ -17,7 +17,7 @@ var common = require('../common');
 var errors = require('../errors');
 
 var COLUMNS_DEFAULT = 'accesskeyid,status,updated';
-var COLUMNS_LONG = 'accesskeyid,status,description,created,updated';
+var COLUMNS_LONG = 'accesskeyid,status,description,created,updated,scope';
 var SORT_DEFAULT = 'created';
 
 function do_accesskeys(subcmd, opts, args, cb) {
@@ -54,6 +54,12 @@ function do_accesskeys(subcmd, opts, args, cb) {
             if (opts.json) {
                 common.jsonStream(keys);
             } else {
+                keys.forEach(function (k) {
+                    if (k.scope && typeof k.scope === 'object') {
+                        k.scope = JSON.stringify(k.scope);
+                    }
+                });
+
                 var columns = opts.long ? COLUMNS_LONG : COLUMNS_DEFAULT;
                 if (opts.o) {
                     columns = opts.o.toLowerCase();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "triton",
   "description": "Triton CLI and client (https://www.tritondatacenter.com/)",
-  "version": "7.18.0",
+  "version": "7.19.0",
   "author": "Edgecast Cloud (edgecast.io)",
   "homepage": "https://github.com/TritonDataCenter/node-triton",
   "dependencies": {

--- a/test/integration/cli-accesskeys-scope.js
+++ b/test/integration/cli-accesskeys-scope.js
@@ -1,0 +1,235 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2026 Edgecast Cloud LLC.
+ */
+
+/*
+ * Integration tests for the per-bucket scope surface of
+ * `triton accesskey create|update|list|get`.
+ *
+ * Covers:
+ *   - create --scope=JSON         (round-trip)
+ *   - create --scope=@FILE        (file source)
+ *   - create --scope='not json'   (local UsageError)
+ *   - update KEY scope='{...}'    (replace scope)
+ *   - update --remove-scope KEY   (clear scope)
+ *   - list -l                     (scope column present)
+ *
+ * Scope validation rules (envelope shape, wildcards, level enum,
+ * size limits) are exercised server-side in sdc-cloudapi /
+ * node-mahi tests; this suite only verifies that node-triton
+ * shuttles the scope correctly through the CLI surface.
+ */
+
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
+
+var backoff = require('backoff');
+var test = require('tap').test;
+
+var h = require('./helpers');
+
+var MAX_CHECK_KEY_TRIES = 10;
+
+// Shared across the create/update/remove/delete steps of the main flow.
+var scopedKey = null;
+
+var SCOPE_RO = {
+    version: 1,
+    permissions: [
+        { bucket: 'test-bucket-ro', level: 'read' }
+    ]
+};
+
+var SCOPE_RW = {
+    version: 1,
+    permissions: [
+        { bucket: 'test-bucket-ro', level: 'readwrite' }
+    ]
+};
+
+var testOpts = {
+    skip: false
+};
+
+if (!h.CONFIG.allowWriteActions) {
+    testOpts.skip = 'requires config.allowWriteActions';
+}
+
+
+test('triton accesskey scope', testOpts, function (suite) {
+
+    suite.test('create --scope=JSON round-trips', function (t) {
+        var cmd = "accesskey create -j --scope='" +
+            JSON.stringify(SCOPE_RO) + "'";
+        h.triton(cmd, function (err, stdout) {
+            if (h.ifErr(t, err, 'accesskey create --scope=JSON')) {
+                return t.end();
+            }
+
+            var response = JSON.parse(stdout);
+            t.type(response.accesskeyid, 'string', 'response.accesskeyid');
+            t.type(response.accesskeysecret, 'string',
+                'response.accesskeysecret');
+            t.same(response.scope, SCOPE_RO,
+                'response.scope deep-equals request');
+
+            delete response.accesskeysecret;
+            scopedKey = response;
+            t.end();
+        });
+    });
+
+    suite.test('get -j returns the same scope', function (t) {
+        h.triton('accesskey get -j ' + scopedKey.accesskeyid,
+            function (err, stdout) {
+                if (h.ifErr(t, err, 'accesskey get')) {
+                    return t.end();
+                }
+                var response = JSON.parse(stdout);
+                t.same(response.scope, SCOPE_RO,
+                    'get returns the same scope envelope');
+                t.end();
+            });
+    });
+
+    suite.test('list -l includes scope column', function (t) {
+        h.triton('accesskey list -l', function (err, stdout) {
+            if (h.ifErr(t, err, 'accesskey list -l')) {
+                return t.end();
+            }
+            t.match(stdout, /\bSCOPE\b/i, 'header has SCOPE column');
+            t.end();
+        });
+    });
+
+    suite.test('create --scope=@FILE round-trips', function (t) {
+        var tmpFile = path.join(os.tmpdir(),
+            'triton-scope-' + process.pid + '-' + Date.now() + '.json');
+        fs.writeFileSync(tmpFile, JSON.stringify(SCOPE_RO));
+
+        var cmd = 'accesskey create -j --scope=@' + tmpFile;
+        h.triton(cmd, function (err, stdout) {
+            try {
+                fs.unlinkSync(tmpFile);
+            } catch (_e) { /* ignore */ }
+
+            if (h.ifErr(t, err, 'accesskey create --scope=@FILE')) {
+                return t.end();
+            }
+
+            var response = JSON.parse(stdout);
+            t.type(response.accesskeyid, 'string', 'response.accesskeyid');
+            t.same(response.scope, SCOPE_RO, 'file-loaded scope round-trips');
+
+            // Best-effort cleanup of the ephemeral key.
+            h.triton('accesskey delete -f ' + response.accesskeyid,
+                function () {
+                    t.end();
+                });
+        });
+    });
+
+    suite.test('create --scope=<malformed> fails locally', function (t) {
+        // The single-quoted 'not json' is not parseable as JSON, so
+        // do_create.js should emit a UsageError before any HTTP call.
+        h.triton("accesskey create --scope='not json'",
+            function (err, _stdout, stderr) {
+                t.ok(err, 'expected non-zero exit');
+                t.match(stderr, /--scope is not valid JSON/,
+                    'local UsageError surfaces');
+                t.end();
+            });
+    });
+
+    suite.test('update scope=<new JSON> replaces scope', function (t) {
+        var cmd = 'accesskey update ' + scopedKey.accesskeyid +
+            " scope='" + JSON.stringify(SCOPE_RW) + "'";
+        h.triton(cmd, function (err, stdout) {
+            if (h.ifErr(t, err, 'accesskey update scope=')) {
+                return t.end();
+            }
+            t.match(stdout, 'Updated access key ' + scopedKey.accesskeyid);
+            t.match(stdout, 'fields: scope');
+
+            var call = backoff.call(function checkScope(next) {
+                h.triton('accesskey get -j ' + scopedKey.accesskeyid,
+                    function (err2, stdout2) {
+                        if (h.ifErr(t, err2, 'accesskey get')) {
+                            return next(err2);
+                        }
+                        var response = JSON.parse(stdout2);
+                        if (!response.scope ||
+                            response.scope.permissions[0].level !==
+                            'readwrite') {
+                            return next(new Error(
+                                'scope not yet replicated'));
+                        }
+                        t.same(response.scope, SCOPE_RW,
+                            'updated scope visible via get');
+                        return next();
+                    });
+            }, function (err3) {
+                h.ifErr(t, err3,
+                    'replicated scope not visible after update');
+                t.end();
+            });
+
+            call.failAfter(MAX_CHECK_KEY_TRIES);
+            call.start();
+        });
+    });
+
+    suite.test('update --remove-scope clears scope', function (t) {
+        var cmd = 'accesskey update --remove-scope ' +
+            scopedKey.accesskeyid;
+        h.triton(cmd, function (err) {
+            if (h.ifErr(t, err, 'accesskey update --remove-scope')) {
+                return t.end();
+            }
+
+            var call = backoff.call(function checkCleared(next) {
+                h.triton('accesskey get -j ' + scopedKey.accesskeyid,
+                    function (err2, stdout) {
+                        if (h.ifErr(t, err2, 'accesskey get')) {
+                            return next(err2);
+                        }
+                        var response = JSON.parse(stdout);
+                        if (response.scope !== null) {
+                            return next(new Error(
+                                'scope not yet cleared'));
+                        }
+                        t.equal(response.scope, null,
+                            'scope is null (unrestricted)');
+                        return next();
+                    });
+            }, function (err3) {
+                h.ifErr(t, err3,
+                    'scope clear not visible after update');
+                t.end();
+            });
+
+            call.failAfter(MAX_CHECK_KEY_TRIES);
+            call.start();
+        });
+    });
+
+    suite.test('cleanup: delete scoped key', function (t) {
+        var cmd = 'accesskey delete -f ' + scopedKey.accesskeyid;
+        h.triton(cmd, function (err, stdout) {
+            if (h.ifErr(t, err, 'accesskey delete')) {
+                return t.end();
+            }
+            t.match(stdout, 'Deleted access key "' + scopedKey.accesskeyid);
+            t.end();
+        });
+    });
+
+    suite.end();
+});

--- a/test/integration/cli-accesskeys-scope.js
+++ b/test/integration/cli-accesskeys-scope.js
@@ -186,6 +186,52 @@ test('triton accesskey scope', testOpts, function (suite) {
         });
     });
 
+    suite.test('update -f FILE with scope replaces scope', function (t) {
+        // Following the previous test, scope is currently SCOPE_RW.
+        // Update it back to SCOPE_RO via the -f JSON-FILE form so the
+        // assertion is meaningful.
+        var tmpFile = path.join(os.tmpdir(),
+            'triton-scope-upd-' + process.pid + '-' + Date.now() + '.json');
+        fs.writeFileSync(tmpFile, JSON.stringify({scope: SCOPE_RO}));
+
+        var cmd = 'accesskey update -f ' + tmpFile + ' ' +
+            scopedKey.accesskeyid;
+        h.triton(cmd, function (err, stdout) {
+            try { fs.unlinkSync(tmpFile); } catch (_e) { /* ignore */ }
+
+            if (h.ifErr(t, err, 'accesskey update -f FILE')) {
+                return t.end();
+            }
+            t.match(stdout, 'Updated access key ' + scopedKey.accesskeyid);
+            t.match(stdout, 'fields: scope');
+
+            var call = backoff.call(function checkScope(next) {
+                h.triton('accesskey get -j ' + scopedKey.accesskeyid,
+                    function (err2, stdout2) {
+                        if (h.ifErr(t, err2, 'accesskey get')) {
+                            return next(err2);
+                        }
+                        var response = JSON.parse(stdout2);
+                        if (!response.scope ||
+                            response.scope.permissions[0].level !== 'read') {
+                            return next(new Error(
+                                'scope not yet replicated to read level'));
+                        }
+                        t.same(response.scope, SCOPE_RO,
+                            '-f-updated scope visible via get');
+                        return next();
+                    });
+            }, function (err3) {
+                h.ifErr(t, err3,
+                    '-f scope update not visible after backoff');
+                t.end();
+            });
+
+            call.failAfter(MAX_CHECK_KEY_TRIES);
+            call.start();
+        });
+    });
+
     suite.test('update --remove-scope clears scope', function (t) {
         var cmd = 'accesskey update --remove-scope ' +
             scopedKey.accesskeyid;

--- a/test/integration/cli-rbac-accesskey-scope.js
+++ b/test/integration/cli-rbac-accesskey-scope.js
@@ -1,0 +1,249 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2026 Edgecast Cloud LLC.
+ */
+
+/*
+ * Integration tests for the per-bucket scope surface of
+ * `triton rbac accesskey ...` (RBAC sub-user access keys).
+ *
+ * Mirrors cli-accesskeys-scope.js for the
+ * /:account/users/:user/accesskeys/... CloudAPI routes.
+ *
+ * Covers:
+ *   - rbac accesskey -c --scope=JSON     (round-trip)
+ *   - rbac accesskey -c --scope=@FILE    (file source)
+ *   - rbac accesskey -c --scope='not...' (local UsageError)
+ *   - rbac accesskey -u --scope='{...}'  (replace scope)
+ *   - rbac accesskey -u --remove-scope   (clear scope)
+ *   - rbac accesskeys -l                 (scope column present)
+ *
+ * Scope validation rules (envelope shape, wildcards, level enum,
+ * size limits) are exercised server-side in sdc-cloudapi /
+ * node-mahi tests; this suite only verifies that node-triton
+ * shuttles the scope correctly through the rbac CLI surface.
+ */
+
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
+
+var backoff = require('backoff');
+var test = require('tap').test;
+
+var h = require('./helpers');
+
+var MAX_CHECK_KEY_TRIES = 10;
+
+var scopedKey = null;
+
+var SCOPE_RO = {
+    version: 1,
+    permissions: [
+        { bucket: 'test-bucket-ro', level: 'read' }
+    ]
+};
+
+var SCOPE_RW = {
+    version: 1,
+    permissions: [
+        { bucket: 'test-bucket-ro', level: 'readwrite' }
+    ]
+};
+
+var testOpts = {
+    skip: false
+};
+
+if (!h.CONFIG.allowWriteActions) {
+    testOpts.skip = 'requires config.allowWriteActions';
+}
+
+if (!h.CONFIG.rbacUser) {
+    testOpts.skip = 'requires config.rbacUser';
+}
+
+var rbacUser = h.CONFIG.rbacUser;
+
+
+test('triton rbac accesskey scope', testOpts, function (suite) {
+
+    suite.test('--create --scope=JSON round-trips', function (t) {
+        var cmd = "rbac accesskey -j --create --scope='" +
+            JSON.stringify(SCOPE_RO) + "' " + rbacUser;
+        h.triton(cmd, function (err, stdout) {
+            if (h.ifErr(t, err, 'rbac accesskey --create --scope=JSON')) {
+                return t.end();
+            }
+
+            var response = JSON.parse(stdout);
+            t.type(response.accesskeyid, 'string', 'response.accesskeyid');
+            t.type(response.accesskeysecret, 'string',
+                'response.accesskeysecret');
+            t.same(response.scope, SCOPE_RO,
+                'response.scope deep-equals request');
+
+            delete response.accesskeysecret;
+            scopedKey = response;
+            t.end();
+        });
+    });
+
+    suite.test('rbac accesskey get returns the same scope', function (t) {
+        var cmd = 'rbac accesskey -j ' + rbacUser + ' ' +
+            scopedKey.accesskeyid;
+        h.triton(cmd, function (err, stdout) {
+            if (h.ifErr(t, err, 'rbac accesskey get')) {
+                return t.end();
+            }
+            var response = JSON.parse(stdout);
+            t.same(response.scope, SCOPE_RO,
+                'get returns the same scope envelope');
+            t.end();
+        });
+    });
+
+    suite.test('rbac accesskeys -l includes scope column', function (t) {
+        h.triton('rbac accesskeys -l ' + rbacUser, function (err, stdout) {
+            if (h.ifErr(t, err, 'rbac accesskeys -l')) {
+                return t.end();
+            }
+            t.match(stdout, /\bSCOPE\b/i, 'header has SCOPE column');
+            t.end();
+        });
+    });
+
+    suite.test('--create --scope=@FILE round-trips', function (t) {
+        var tmpFile = path.join(os.tmpdir(),
+            'triton-rbac-scope-' + process.pid + '-' + Date.now() + '.json');
+        fs.writeFileSync(tmpFile, JSON.stringify(SCOPE_RO));
+
+        var cmd = 'rbac accesskey -j --create --scope=@' + tmpFile +
+            ' ' + rbacUser;
+        h.triton(cmd, function (err, stdout) {
+            try {
+                fs.unlinkSync(tmpFile);
+            } catch (_e) { /* ignore */ }
+
+            if (h.ifErr(t, err, 'rbac accesskey --create --scope=@FILE')) {
+                return t.end();
+            }
+
+            var response = JSON.parse(stdout);
+            t.type(response.accesskeyid, 'string', 'response.accesskeyid');
+            t.same(response.scope, SCOPE_RO,
+                'file-loaded scope round-trips');
+
+            // Best-effort cleanup of the ephemeral key.
+            var delCmd = 'rbac accesskey --delete -f ' + rbacUser + ' ' +
+                response.accesskeyid;
+            h.triton(delCmd, function () {
+                t.end();
+            });
+        });
+    });
+
+    suite.test('--create --scope=<malformed> fails locally', function (t) {
+        var cmd = "rbac accesskey --create --scope='not json' " + rbacUser;
+        h.triton(cmd, function (err, _stdout, stderr) {
+            t.ok(err, 'expected non-zero exit');
+            t.match(stderr, /--scope is not valid JSON/,
+                'local UsageError surfaces');
+            t.end();
+        });
+    });
+
+    suite.test('--update --scope=<new JSON> replaces scope', function (t) {
+        var cmd = 'rbac accesskey --update --scope=\'' +
+            JSON.stringify(SCOPE_RW) + '\' ' + rbacUser + ' ' +
+            scopedKey.accesskeyid;
+        h.triton(cmd, function (err, stdout) {
+            if (h.ifErr(t, err, 'rbac accesskey --update --scope')) {
+                return t.end();
+            }
+            t.match(stdout, 'Updated access key ' + scopedKey.accesskeyid);
+            t.match(stdout, 'fields: scope');
+
+            var call = backoff.call(function checkScope(next) {
+                var getCmd = 'rbac accesskey -j ' + rbacUser + ' ' +
+                    scopedKey.accesskeyid;
+                h.triton(getCmd, function (err2, stdout2) {
+                    if (h.ifErr(t, err2, 'rbac accesskey get')) {
+                        return next(err2);
+                    }
+                    var response = JSON.parse(stdout2);
+                    if (!response.scope ||
+                        response.scope.permissions[0].level !==
+                        'readwrite') {
+                        return next(new Error(
+                            'scope not yet replicated'));
+                    }
+                    t.same(response.scope, SCOPE_RW,
+                        'updated scope visible via get');
+                    return next();
+                });
+            }, function (err3) {
+                h.ifErr(t, err3,
+                    'replicated scope not visible after update');
+                t.end();
+            });
+
+            call.failAfter(MAX_CHECK_KEY_TRIES);
+            call.start();
+        });
+    });
+
+    suite.test('--update --remove-scope clears scope', function (t) {
+        var cmd = 'rbac accesskey --update --remove-scope ' +
+            rbacUser + ' ' + scopedKey.accesskeyid;
+        h.triton(cmd, function (err) {
+            if (h.ifErr(t, err, 'rbac accesskey --update --remove-scope')) {
+                return t.end();
+            }
+
+            var call = backoff.call(function checkCleared(next) {
+                var getCmd = 'rbac accesskey -j ' + rbacUser + ' ' +
+                    scopedKey.accesskeyid;
+                h.triton(getCmd, function (err2, stdout) {
+                    if (h.ifErr(t, err2, 'rbac accesskey get')) {
+                        return next(err2);
+                    }
+                    var response = JSON.parse(stdout);
+                    if (response.scope !== null) {
+                        return next(new Error(
+                            'scope not yet cleared'));
+                    }
+                    t.equal(response.scope, null,
+                        'scope is null (unrestricted)');
+                    return next();
+                });
+            }, function (err3) {
+                h.ifErr(t, err3,
+                    'scope clear not visible after update');
+                t.end();
+            });
+
+            call.failAfter(MAX_CHECK_KEY_TRIES);
+            call.start();
+        });
+    });
+
+    suite.test('cleanup: delete scoped key', function (t) {
+        var cmd = 'rbac accesskey --delete -f ' + rbacUser + ' ' +
+            scopedKey.accesskeyid;
+        h.triton(cmd, function (err, stdout) {
+            if (h.ifErr(t, err, 'rbac accesskey --delete')) {
+                return t.end();
+            }
+            t.match(stdout, 'Deleted access key "' + scopedKey.accesskeyid);
+            t.end();
+        });
+    });
+
+    suite.end();
+});


### PR DESCRIPTION
When creating new accesskeys we should be able to pass a bucket-scope on creation in order to restrict access.

Portions generated by:  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>